### PR TITLE
Update to zig 0.16.0

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -40,13 +40,13 @@ fn update_wayland(toolbox: *Toolbox, path: *const Paths) !void {
 
     try toolbox.clone(.wayland, path.getTmp());
 
-    var tmp_dir = try std.fs.openDirAbsolute(tmp_src_path, .{
+    var tmp_dir = try std.Io.Dir.openDirAbsolute(toolbox.getIo(), tmp_src_path, .{
         .iterate = true,
     });
-    defer tmp_dir.close();
+    defer tmp_dir.close(toolbox.getIo());
 
     var it = tmp_dir.iterate();
-    while (try it.next()) |*entry| {
+    while (try it.next(toolbox.getIo())) |*entry| {
         if ((std.mem.startsWith(u8, entry.name, "wayland-client") or
             std.mem.startsWith(u8, entry.name, "wayland-server") or
             std.mem.startsWith(u8, entry.name, "wayland-util")) and
@@ -62,7 +62,7 @@ fn update_wayland(toolbox: *Toolbox, path: *const Paths) !void {
     }
 
     const wayland_version = try toolbox.reference(.wayland);
-    var wayland_version_h = try tmp_dir.readFileAlloc(toolbox.getAllocator(), "wayland-version.h.in", std.math.maxInt(usize));
+    var wayland_version_h = try tmp_dir.readFileAlloc(toolbox.getIo(), "wayland-version.h.in", toolbox.getAllocator(), .unlimited);
     wayland_version_h = try std.mem.replaceOwned(u8, toolbox.getAllocator(), wayland_version_h, "@WAYLAND_VERSION@", wayland_version);
 
     var tokit = std.mem.tokenizeScalar(u8, wayland_version, '.');
@@ -99,7 +99,8 @@ fn update_wayland(toolbox: *Toolbox, path: *const Paths) !void {
         },
     });
 
-    try std.fs.deleteTreeAbsolute(path.getTmp());
+    std.debug.assert(std.fs.path.isAbsolute(path.getTmp()));
+    try std.Io.Dir.deleteTree(.cwd(), toolbox.getIo(), path.getTmp());
 }
 
 fn update_protocols(toolbox: *Toolbox, path: *const Paths) !void {
@@ -180,18 +181,21 @@ fn update_protocols(toolbox: *Toolbox, path: *const Paths) !void {
         });
     }
 
-    try std.fs.deleteTreeAbsolute(path.getTmp());
+    std.debug.assert(std.fs.path.isAbsolute(path.getTmp()));
+    try std.Io.Dir.deleteTree(.cwd(), toolbox.getIo(), path.getTmp());
 }
 
 fn update(toolbox: *Toolbox) !void {
     const path = try Paths.init(toolbox);
 
-    std.fs.deleteTreeAbsolute(path.getWayland()) catch |err| {
-        switch (err) {
-            error.FileNotFound => {},
-            else => return err,
-        }
-    };
+    // there is no FileNotFound in DeleteTreeError in 0.16
+    std.debug.assert(std.fs.path.isAbsolute(path.getWayland()));
+    try std.Io.Dir.deleteTree(.cwd(), toolbox.getIo(), path.getWayland()); // catch |err| {
+    //     switch (err) {
+    //         error.FileNotFound => {},
+    //         else => return err,
+    //     }
+    // };
 
     try update_wayland(toolbox, &path);
     try update_protocols(toolbox, &path);

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,13 +1,13 @@
 .{
     .name = .wayland_zig,
-    .version = "1.0.0",
+    .version = "1.0.1",
     .dependencies = .{
         .toolbox = .{
-            .url = "git+https://github.com/tiawl/toolbox?ref=1.12.6#79c1dffe608a9c4a7dcf11f98f1dc88b9b46e9f5",
-            .hash = "toolbox-1.12.6-kRAu4BJbAAAGPWPltdn1vwY83xau2Zh9015JTQ0MZjyM",
+            .url = "git+https://github.com/apm5127/toolbox.git?ref=update-zig#53d8342f24a9213fa6454ab6f15605c6ac35c8ab",
+            .hash = "toolbox-1.12.7-kRAu4DRlAAC0RRGTn0MRUxiv6TKMUAvWqnnXKs2UF3F7",
         },
     },
-    .minimum_zig_version = "0.15.1",
+    .minimum_zig_version = "0.16.0",
     .fingerprint = 0x879377398f3e6626,
     .paths = .{
         "build.zig",


### PR DESCRIPTION
I've updated the build.zig in my forks of [glfw.zig](https://github.com/apm5127/glfw.zig/tree/update-zig), [wayland.zig](https://github.com/apm5127/wayland.zig/tree/update-zig), [vulkan.zig](https://github.com/apm5127/vulkan.zig/tree/update-zig), [x11.zig](https://github.com/apm5127/x11.zig/tree/update-zig), and [toolbox](https://github.com/apm5127/toolbox/tree/update-zig) to compile using the latest Zig `master` branch, version `0.16.0-dev.2510+bcb5218a2`.

Since Zig 0.16.0 is not released yet, I think the updates could go into a branch tracking Zig `master` until 0.16.0 releases. Could you please add a branch called `zig-master` or something for merging Zig 0.16.0 updates until then?

I had to change the dependencies in the build.zig.zon files to my forks, so they will require updating after merging the build.zig files.

Most of the changes were related to the new std.Io interface.