### PR TITLE
Fix build not working, hash didn't get updated

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,7 +4,7 @@
     .dependencies = .{
         .wayland = .{
             .url = "git+https://gitlab.freedesktop.org/wayland/wayland?ref=1.24.91#e6aeed9816f9fa202ed49318b7b25f867676999a",
-            .hash = "N-V-__8AAHr0JACeIVK5CkrixKeVluYqJ4OPDz1ss5bvTWd9",
+            .hash = "N-V-__8AAEz1JADNj6oKANmNKajvf6zZZkXQKsB05Px-n9cp",
         },
         .@"wayland-protocols" = .{
             .url = "git+https://gitlab.freedesktop.org/wayland/wayland-protocols?ref=1.48#02e63e74a807afed95bc25a386173110afef24e3",


### PR DESCRIPTION
If you try to build the repo right now it fails with
```
/wayland.zig/build.zig.zon:7:21: error: hash mismatch: manifest declares N-V-__8AAHr0JACeIVK5CkrixKeVluYqJ4OPDz1ss5bvTWd9 but the fetched package has N-V-__8AAEz1JADNj6oKANmNKajvf6zZZkXQKsB05Px-n9cp
            .hash = "N-V-__8AAHr0JACeIVK5CkrixKeVluYqJ4OPDz1ss5bvTWd9
```

Updating the hash so it builds again